### PR TITLE
fix BlockUSBMount go tag and RemountUSBMode type

### DIFF
--- a/santa/santa.go
+++ b/santa/santa.go
@@ -32,8 +32,8 @@ type Preflight struct {
 	BatchSize                     int        `json:"batch_size" toml:"batch_size"`
 	EnableBundles                 bool       `json:"enable_bundles" toml:"enable_bundles"`
 	EnabledTransitiveallowlisting bool       `json:"enabled_transitive_allowlisting" toml:"enabled_transitive_allowlisting"`
-	BlockUSBMount                 bool       `json:"block_usb_mount toml:block_usb_mount"`
-	RemountUSBMode                string     `json:"remount_usb_mode" toml:"remount_usb_mode"`
+	BlockUSBMount                 bool       `json:"block_usb_mount" toml:"block_usb_mount"`
+	RemountUSBMode                []string   `json:"remount_usb_mode" toml:"remount_usb_mode"`
 	CleanSync                     bool       `json:"clean_sync" toml:"clean_sync"`
 }
 


### PR DESCRIPTION
`BlockUSBMount` was missing some quotes in the Go tag and `RemountUSBMode` is treated as a `[]string` in Santa (https://github.com/google/santa/blob/cc3177502c1729530f134769a9dcc223c3db3680/Source/santasyncservice/SNTSyncPreflight.m#L165)